### PR TITLE
[Travis CI] Run tests with Play Framework, not only sbt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+project/project/
+project/target/
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: scala
-scala:
-  - 2.9.1
+env:
+  - PLAY_VERSION=2.0
+before_script: ./travis/setup
+script: ./travis/play-framework/play test
+notifications:
+  # Email notifications are disabled to not annoy anybody.
+  # See http://about.travis-ci.org/docs/user/build-configuration/ to learn more
+  # about configuring notification recipients and more.
+  email: false

--- a/test/functionals/ApplicationSpec.scala
+++ b/test/functionals/ApplicationSpec.scala
@@ -10,9 +10,7 @@ import play.api.test.{FakeApplication, FakeRequest}
  * Date: 13/03/12
  * Time: 21:53
  */
-/*
 class ApplicationSpec extends Specification {
-  /*
   "Application" should {
     "Action index" in {
       running(FakeApplication()) {
@@ -26,4 +24,3 @@ class ApplicationSpec extends Specification {
   }
   
 }
-*/

--- a/travis/setup
+++ b/travis/setup
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PLAY_HOME=./travis/play-framework
+PLAY_PACKAGE=play-${PLAY_VERSION}
+PLAY_ZIP=${PLAY_PACKAGE}.zip
+PLAY_DOWNLOAD=http://download.playframework.org/releases/${PLAY_ZIP}
+
+wget ${PLAY_DOWNLOAD} 
+unzip -q ${PLAY_ZIP} 
+mv ${PLAY_PACKAGE} ${PLAY_HOME}
+


### PR DESCRIPTION
I saw you've plugged your project on Travis CI, great ! Actually Travis can do even more for you:

As described in this [sample](https://github.com/gildegoma/travis-ci-ScalaOnPlay-sample), you can install Play2 framework on the fly, and thus run the whole set of tests that rely on the framework stack.

For the demonstration, I only enabled the ApplicationSpec test example... see http://travis-ci.org/#!/gildegoma/persistance/builds/1088898
